### PR TITLE
V1.6.1/dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ v1.6.1-1.6
 ## Features
 
 - Tracks various player action stats including:
-  - Captures
-  - Knock Outs (in-battle)
-  - Resurrections
-  - Fish-ups
-  - Egg hatchings
+    - Captures
+    - Knock Outs (in-battle)
+    - Resurrections
+    - Fish-ups
+    - Egg hatchings
 - Tracks both counts and streaks for every stat. Counts are for the lifetime of the player in a given world, and streaks are broken if the player performs that action on another species/form.
-  - Some odd variants are mapped back to the Normal variant.
+    - Some odd variants are mapped back to the Normal variant.
 - Adds a Counter item to view your current stats.
 - Commands to get and modify scores for a given player.
 
 ## Dependencies
 
 - [Cobblemon](https://www.notion.so/Cobblemon-22157e0d4afd80a49896c70a775a3c7f?pvs=21)
-- [Cobblemon Tim Core](https://www.notion.so/Tim-Core-22057e0d4afd809b9c02e78f26805376?pvs=21)
+- [Tim Core](https://www.notion.so/Tim-Core-22057e0d4afd809b9c02e78f26805376?pvs=21)
 
 ## Testing
 
@@ -59,6 +59,10 @@ As a quick test for the counting functionality, jump into a fresh world and give
 [Events](https://www.notion.so/Events-28357e0d4afd81229051d2740c2433bc?pvs=21)
 
 [CounterManager](https://www.notion.so/CounterManager-28357e0d4afd8142bf88c61c9c4146f6?pvs=21)
+
+## Known Issues
+
+- v1.6.1-1.6.0 had issues with handling stats when it’d been told to ignore forms. v1.6.1-1.6.1 remedies this.
 
 ## Roadmap
 

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterMod.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/CounterMod.kt
@@ -44,11 +44,11 @@ object CounterMod : AbstractMod<CounterMod.CounterConfig>(MOD_ID, CounterConfig:
             ScoreTypes
         }
 
-        val breakStreakOnForm: Set<String> = CounterTypeRegistry.types().toSet()
+        val ignoreFormFor: Set<String> = emptySet()
         val broadcast: Set<String> = CounterTypeRegistry.types().toSet()
     }
 
-    fun breakStreakOnForm(counterType: CounterType): Boolean = config.breakStreakOnForm.contains(counterType.type)
+    fun breakStreakOnForm(counterType: CounterType): Boolean = !config.ignoreFormFor.contains(counterType.type)
 
     object PlayerInstancedDataStores {
         val COUNTER = PlayerInstancedDataStoreTypes.register(

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/AbstractCounterManager.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/AbstractCounterManager.kt
@@ -1,6 +1,7 @@
 package us.timinc.mc.cobblemon.counter.api
 
 import net.minecraft.resources.ResourceLocation
+import us.timinc.mc.cobblemon.counter.CounterMod.breakStreakOnForm
 
 abstract class AbstractCounterManager {
     abstract val counters: Map<CounterType, Counter>
@@ -16,7 +17,7 @@ abstract class AbstractCounterManager {
     fun getStreakScore(counterType: CounterType, species: ResourceLocation? = null, form: String? = null): Int {
         val streak = getStreak(counterType)
         if (species === null) return streak.count
-        if (form === null) return if (species == streak.species) streak.count else 0
+        if (form === null || !breakStreakOnForm(counterType)) return if (species == streak.species) streak.count else 0
         return if (species == streak.species && form == streak.form) streak.count else 0
     }
 
@@ -25,7 +26,7 @@ abstract class AbstractCounterManager {
             total + speciesEntry.values.fold(0) { speciesTotal, speciesCount -> speciesTotal + speciesCount }
         }
         val speciesRecord = getCounter(counterType).count[species] ?: return 0
-        if (form === null) return speciesRecord.values.fold(0) { speciesTotal, speciesCount -> speciesTotal + speciesCount }
+        if (form === null || !breakStreakOnForm(counterType)) return speciesRecord.values.fold(0) { speciesTotal, speciesCount -> speciesTotal + speciesCount }
         return speciesRecord.getOrDefault(form, 0)
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/CounterManager.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/CounterManager.kt
@@ -83,7 +83,7 @@ class CounterManager(
     @Suppress("MemberVisibilityCanBePrivate")
     fun record(
         pokemon: Pokemon,
-        counterType: CounterType
+        counterType: CounterType,
     ) {
         val initialSpeciesId = pokemon.species.resourceIdentifier
         val initialFormName = pokemon.form.name

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/spawning/CountSpawningCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/spawning/CountSpawningCondition.kt
@@ -8,6 +8,7 @@ import us.timinc.mc.cobblemon.counter.extension.getCounterManager
 class CountSpawningCondition : AppendageCondition {
     @Suppress("MemberVisibilityCanBePrivate")
     val counts: List<CountRequirement>? = null
+
     @Suppress("MemberVisibilityCanBePrivate")
     val streaks: List<CountRequirement>? = null
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=true
 
 modId=cobbled_counter
 modCobblemonVersion=1.6.1
-modMyVersion=1.6.0
+modMyVersion=1.6.1
 modName=Counter
 modDescription=What if the game kept track of how many times you did a thing, in Cobblemon?
 modAuthor=timinc aka Timothy Metcalfe


### PR DESCRIPTION
* Swapped the breakStreakOnForm option for an ignoreFormFor option, effectively inverting its logic.
* Fixed not tracking the form not giving a valid score anymore.