### PR TITLE
v1.7.1-1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cobbled Counter
 
-v1.7.1-1.8.0
+v1.7.1-1.8.1
 
 [Modrinth](https://modrinth.com/mod/cobblemon-counter)
 

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/CounterManager.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/CounterManager.kt
@@ -4,6 +4,8 @@ import com.cobblemon.mod.common.CobblemonNetwork.sendPacket
 import com.cobblemon.mod.common.api.storage.player.InstancedPlayerData
 import com.cobblemon.mod.common.net.messages.client.SetClientPlayerDataPacket
 import com.cobblemon.mod.common.pokemon.Pokemon
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.cobblemon.mod.common.util.cobblemonResource
 import com.cobblemon.mod.common.util.getPlayer
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.PrimitiveCodec
@@ -92,7 +94,7 @@ class CounterManager(
 
         val formOverride = SpeciesFormOverride.Manager.findMatch(pokemon)
 
-        val speciesId = if (formOverride === null) initialSpeciesId else ResourceLocation.parse(formOverride.species)
+        val speciesId = if (formOverride === null) initialSpeciesId else formOverride.species.asIdentifierDefaultingNamespace()
         val formName =
             if (!breakStreakOnForm(counterType)) "untracked" else if (formOverride === null) initialFormName else formOverride.form
 
@@ -107,7 +109,18 @@ class CounterManager(
 
         val counter = getCounter(counterType)
         val speciesRecord = counter.count.getOrPut(speciesId) { mutableMapOf() }
+        val minecraftNamespacedSpecies = ResourceLocation.fromNamespaceAndPath("minecraft", speciesId.path)
+        val minecraftSpeciesRecord =
+            counter.count.getOrDefault(minecraftNamespacedSpecies, mapOf())
+        minecraftSpeciesRecord.forEach { (formName, count) ->
+            speciesRecord[formName] = speciesRecord.getOrDefault(formName, 0) + count
+        }
+        counter.count.remove(minecraftNamespacedSpecies)
         speciesRecord[formName] = speciesRecord.getOrDefault(formName, 0) + 1
+
+        if (counter.streak.species == minecraftNamespacedSpecies) {
+            counter.streak.species = speciesId
+        }
 
         var streakChanged = false
         if (counter.streak.wouldBreak(speciesId, formName)) {

--- a/common/src/main/resources/data/cobbled_counter/species_form_override/unown.json
+++ b/common/src/main/resources/data/cobbled_counter/species_form_override/unown.json
@@ -1,0 +1,6 @@
+{
+  "targetSpecies": "unown",
+  "targetForms": ["B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "!", "?"],
+  "species": "unown",
+  "form": "Normal"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=true
 
 modId=cobbled_counter
 modCobblemonVersion=1.7.1
-modMyVersion=1.8.0
+modMyVersion=1.8.1
 modName=Counter
 modDescription=What if the game kept track of how many times you did a thing, in Cobblemon?
 modAuthor=timinc aka Timothy Metcalfe


### PR DESCRIPTION
* Added unown SpeciesFormOverride. No more Unown F.
* Fixed issue with SpeciesFormOverride conflicting with regular namespace. If you had your streak randomly resetting, this was the cause. It will clean up after itself now without affecting your score adversely. Highly recommend updating!